### PR TITLE
Update Airbrake Heroku addon name

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
   },
   "image": "heroku/ruby",
   "addons": [
-    "airbrake:free_heroku",
+    "airbrake:free-hrku",
     "heroku-postgresql:hobby-dev",
     "mailgun:starter"
   ]


### PR DESCRIPTION
Airbrake has changed the name of their free plan on Heroku.
